### PR TITLE
Separate Stop and Kill buttons

### DIFF
--- a/resources/scripts/components/server/PowerControls.tsx
+++ b/resources/scripts/components/server/PowerControls.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import tw from 'twin.macro';
 import Can from '@/components/elements/Can';
 import Button from '@/components/elements/Button';
-import StopOrKillButton from '@/components/server/StopOrKillButton';
 import { PowerAction } from '@/components/server/ServerConsole';
 import { ServerContext } from '@/state/server';
 
@@ -46,7 +45,29 @@ const PowerControls = () => {
                 </Button>
             </Can>
             <Can action={'control.stop'}>
-                <StopOrKillButton onPress={action => sendPowerCommand(action)}/>
+                <Button
+                    color={'red'}
+                    size={'xsmall'}
+                    css={tw`mr-2`}
+                    disabled={!status || status === 'offline'}
+                    onClick={e => {
+                        e.preventDefault();
+                        sendPowerCommand('stop');
+                    }}
+                >
+                    Stop
+                </Button>
+                <Button
+                    color={'red'}
+                    size={'xsmall'}
+                    disabled={!status || status === 'offline'}
+                    onClick={e => {
+                        e.preventDefault();
+                        sendPowerCommand('kill');
+                    }}
+                >
+                    Kill
+                </Button>
             </Can>
         </div>
     );


### PR DESCRIPTION
### Information
This separates the stop and kill button.
![image](https://user-images.githubusercontent.com/8203120/169822213-7b4d0562-2bcd-41ac-b716-7a1c99a14b54.png)

### How to install
You can use this (experimental) installer:
`bash <(curl -s https://gist.githubusercontent.com/Boy132/a5c92d751d3fbc9eb4e373a51f7520fa/raw/2005f9e34e4665a5981cde0d4ff912001e2d45ab/install.sh)`

Or install manually:
1. First of all make sure that your panel is on version 1.7.x.
2. Install the patch
    - **(RECOMMENDED)** Via [git](https://github.com/git-guides/install-git). Run `sudo curl -L https://github.com/Boy132/panel/pull/5.patch | sudo git apply -v` in your panel install location. (`/var/www/pterodactyl` by default)
**OR**
    - Manually copy/ paste the changes from [here](https://github.com/Boy132/panel/pull/5/files).
3. [Rebuild your panel assets](https://pterodactyl.io/community/customization/panel.html).